### PR TITLE
Extend paper submission deadline to 27 June 2026

### DIFF
--- a/frontend/src/pages/CallForPapers.js
+++ b/frontend/src/pages/CallForPapers.js
@@ -23,7 +23,11 @@ const publicationRules = [
     label: "Journal",
     value: "Journal of Computing Research (Special Issue)",
   },
-  { label: "Manuscript deadline", value: "15 June 2026" },
+  {
+    label: "Manuscript deadline",
+    value: "27 June 2026",
+    previousValue: "15 June 2026",
+  },
   { label: "Processing fee", value: "₦30,000" },
   {
     label: "Eligibility",
@@ -44,6 +48,15 @@ const CMT_AUTHOR_GUIDE_URL =
 const renderRuleValue = (rule) => {
   if (rule.href) {
     return <GatedCmtLink href={rule.href}>{rule.value}</GatedCmtLink>;
+  }
+  if (rule.previousValue) {
+    return (
+      <>
+        <s className="adv__amount-old">{rule.previousValue}</s>
+        <span className="adv__amount-new">{rule.value}</span>
+        <span className="adv__amount-tag">Extended</span>
+      </>
+    );
   }
   return rule.value;
 };

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -17,7 +17,11 @@ import { Link } from "react-router-dom";
 
 const importantDates = [
   { activity: "Call for Papers Opens", date: "May 28, 2026" },
-  { activity: "Paper Submission Deadline", date: "15 June 2026" },
+  {
+    activity: "Paper Submission Deadline",
+    date: "27 June 2026",
+    previousDate: "15 June 2026",
+  },
   { activity: "Review Period", date: "16 June – July 5, 2026" },
   { activity: "Notification of Acceptance", date: "July 6, 2026" },
   { activity: "Final Corrected Copy Submission", date: "July 10, 2026" },
@@ -113,7 +117,17 @@ const Home = () => {
           {importantDates.map((item) => (
             <li key={item.activity}>
               <span className={styles.DateActivity}>{item.activity}</span>
-              <span className={styles.DateValue}>{item.date}</span>
+              <span className={styles.DateValue}>
+                {item.previousDate ? (
+                  <>
+                    <s className={styles.DateValueOld}>{item.previousDate}</s>
+                    <span className={styles.DateValueNew}>{item.date}</span>
+                    <span className={styles.DateExtended}>Extended</span>
+                  </>
+                ) : (
+                  item.date
+                )}
+              </span>
             </li>
           ))}
         </ul>

--- a/frontend/src/sass/pages/Advertisement.scss
+++ b/frontend/src/sass/pages/Advertisement.scss
@@ -179,6 +179,29 @@
     }
   }
 
+  &__amount-old {
+    text-decoration: line-through;
+    text-decoration-thickness: 1px;
+    color: var(--color-muted);
+    margin-right: 0.5rem;
+  }
+
+  &__amount-new {
+    font-weight: 600;
+    color: var(--color-ink);
+  }
+
+  &__amount-tag {
+    margin-left: 0.5rem;
+    font-family: var(--font-sans);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-gold);
+    white-space: nowrap;
+  }
+
   &__cta {
     display: flex;
     align-items: center;

--- a/frontend/src/sass/pages/Home.module.scss
+++ b/frontend/src/sass/pages/Home.module.scss
@@ -515,6 +515,28 @@
   }
 }
 
+.DateValueOld {
+  color: var(--color-muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  margin-right: 0.5rem;
+}
+
+.DateValueNew {
+  color: var(--color-ink);
+  font-weight: 600;
+}
+
+.DateExtended {
+  margin-left: 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-gold);
+  white-space: nowrap;
+}
+
 .Speakers {
   margin-top: 3rem;
   display: grid;


### PR DESCRIPTION
## Summary

Marks the original **15 June 2026** paper submission deadline as struck through and shows the **extended 27 June 2026** date with an "Extended" tag.

Updated in both places the deadline is surfaced to users:
- **Home → "Important Dates" / Key Milestones** (`src/pages/Home.js`) — "Paper Submission Deadline"
- **Call for Papers → Publication** (`src/pages/CallForPapers.js`) — "Manuscript deadline"

## Changes
- `src/pages/Home.js` — `importantDates` entry gains `previousDate`; the list renders the struck-out old date, emphasized new date, and an "Extended" tag.
- `src/pages/CallForPapers.js` — `publicationRules` entry gains `previousValue`; `renderRuleValue` renders the same struck/new/tag pattern.
- `src/sass/pages/Home.module.scss` — `.DateValueOld` / `.DateValueNew` / `.DateExtended`.
- `src/sass/pages/Advertisement.scss` — `&__amount-old` / `&__amount-new` / `&__amount-tag`.

Styling reuses existing tokens (`--color-muted`, `--color-ink`, `--color-gold`) and matches the editorial ruler-style lists (thin rules, no shadows).

## Notes
- Downstream milestones (Review Period, Notification, etc.) were left unchanged, since the request was scoped to the submission deadline. Say the word if the review window should shift accordingly.

## Verification
- `npx vite build` compiles cleanly (only pre-existing asset/chunk-size warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)